### PR TITLE
Add concentration-tracking reward and plotting examples

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pandas as pd
+import pickle
+import pytest
+
+import main
+from pse_environments.cstr import CSTR1
+from dream_models import MLP
+
+
+@pytest.fixture
+def settings(tmp_path):
+    """Provide minimal settings and synthetic test data for pytest."""
+    s = main.get_settings()
+    # convenience alias used by test scripts
+    s['process'] = s['environment']['process']
+
+    # create synthetic test dataset
+    state_names = ['c', 'T']
+    control_names = ['roh', 'Fc']
+    data = pd.DataFrame(
+        np.zeros((5, len(state_names) + len(control_names))),
+        columns=state_names + control_names,
+    )
+    test_data = {0: data}
+    data_path = tmp_path / 'test_data.pkl'
+    with open(data_path, 'wb') as f:
+        pickle.dump(test_data, f)
+    s['test_data_path'] = str(data_path)
+
+    # populate process-specific metadata expected by tests
+    s['CSTR1'] = {
+        'state_names': state_names,
+        'control_names': control_names,
+        'n_states': len(state_names),
+        'n_controls': len(control_names),
+    }
+    # ensure testing options exist
+    s.setdefault('dream_model_testing', {})
+    s['dream_model_testing']['plot_test'] = False
+    s['model_name'] = 'test_model'
+    return s
+
+
+@pytest.fixture
+def env(settings):
+    """Return a minimal environment wrapper exposing the process model."""
+    process_model = CSTR1(delta_t=settings['delta_t'])
+
+    class DummyEnv:
+        def __init__(self, process_model):
+            self.process_model = process_model
+
+    return DummyEnv(process_model)
+
+
+@pytest.fixture
+def model(env, settings):
+    """Instantiate a small neural network model for testing."""
+    pm = env.process_model
+    model = MLP(
+        in_features=pm.n_states + pm.n_actions,
+        out_features=pm.n_states,
+        hidden_layer_sizes=[8],
+        predict_delta=True,
+        use_weight_normalization=False,
+        device=settings['device'],
+    )
+    return model

--- a/prrl_experiments.py
+++ b/prrl_experiments.py
@@ -1,0 +1,135 @@
+"""Lightweight PRRL experiment suite.
+
+This script runs a minimal set of experiments illustrating the workflow
+outlined in the project notes:
+
+1. Train a base SAC policy on the nominal CSTR1Env environment.
+2. Compare different strategies on a perturbed environment:
+   - Tabula rasa (train from scratch)
+   - Base policy only
+   - Base + Residual policy
+3. Demonstrate progressive residual learning across multiple tasks and
+   evaluate retention of earlier task performance.
+
+The experiments are intentionally small to keep runtime short.  They do
+not aim to produce strong control performance; instead they provide code
+structure that researchers can extend with longer training runs and
+richer metrics/plots.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+from stable_baselines3 import SAC
+from stable_baselines3.common.evaluation import evaluate_policy
+
+from residual_cstr_agent import make_env, ResidualWrapper, train_base
+
+
+@dataclass
+class EvalResult:
+    label: str
+    mean_reward: float
+
+
+def train_sac(env, total_timesteps: int = 100) -> SAC:
+    model = SAC("MlpPolicy", env, verbose=0)
+    model.learn(total_timesteps=total_timesteps)
+    return model
+
+
+def evaluate_wrapper(wrapper, episodes: int = 5) -> EvalResult:
+    class _ZeroPolicy:
+        def __init__(self, action_space):
+            self.action_space = action_space
+
+        def predict(self, obs, state=None, episode_start=None, deterministic=True):
+            return np.zeros(self.action_space.shape), state
+
+    policy = _ZeroPolicy(wrapper.action_space)
+    mean, _ = evaluate_policy(policy, wrapper, n_eval_episodes=episodes, warn=False)
+    return EvalResult("wrapper", mean)
+
+
+def run_base_training(timesteps: int = 100) -> SAC:
+    base = train_base(total_timesteps=timesteps)
+    env = make_env()
+    mean, _ = evaluate_policy(base, env, n_eval_episodes=5, warn=False)
+    print(f"Base policy mean reward: {mean:.2f}")
+    return base
+
+
+def rrl_comparison(base_model: SAC, timesteps: int = 100):
+    task_env = make_env(param_overrides={"T_c": 0.40})
+
+    tabula_model = train_sac(task_env, timesteps)
+    tabula_reward, _ = evaluate_policy(tabula_model, task_env, n_eval_episodes=5, warn=False)
+
+    base_reward, _ = evaluate_policy(base_model, task_env, n_eval_episodes=5, warn=False)
+
+    residual_env = ResidualWrapper(task_env, base_model)
+    residual_model = train_sac(residual_env, timesteps)
+    residual_reward = evaluate_wrapper(ResidualWrapper(task_env, base_model, [residual_model])).mean_reward
+
+    print("RRL comparison (mean reward over 5 episodes):")
+    print(f"  Tabula Rasa     : {tabula_reward:.2f}")
+    print(f"  Base Only       : {base_reward:.2f}")
+    print(f"  Base + Residual : {residual_reward:.2f}")
+    return residual_model
+
+
+def progressive_learning(base_model: SAC, overrides: List[Dict[str, float]], timesteps: int = 100):
+    residual_models: List[SAC] = []
+    for idx, params in enumerate(overrides, start=1):
+        env = make_env(param_overrides=params)
+        wrapper = ResidualWrapper(env, base_model, residual_models.copy())
+        model = train_sac(wrapper, timesteps)
+        residual_models.append(model)
+        print(f"Trained residual for task {idx} with params {params}")
+
+        # Evaluate retention on all seen tasks
+        for j, prev_params in enumerate(overrides[:idx], start=1):
+            eval_env = make_env(param_overrides=prev_params)
+            eval_wrapper = ResidualWrapper(eval_env, base_model, residual_models[:j])
+            result = evaluate_wrapper(eval_wrapper)
+            print(f"  Eval task {j}: mean reward {result.mean_reward:.2f}")
+    return residual_models
+
+
+def ablation_remove_pnn(base_model: SAC, overrides: List[Dict[str, float]], timesteps: int = 100):
+    model: Optional[SAC] = None
+    for idx, params in enumerate(overrides, start=1):
+        env = make_env(param_overrides=params)
+        wrapper = ResidualWrapper(env, base_model, [model] if model else [])
+        if model is None:
+            model = train_sac(wrapper, timesteps)
+        else:
+            model.set_env(wrapper)
+            model.learn(total_timesteps=timesteps)
+        base_eval_env = make_env(param_overrides=overrides[0])
+        base_eval_wrapper = ResidualWrapper(base_eval_env, base_model, [model])
+        result = evaluate_wrapper(base_eval_wrapper)
+        print(f"After training task {idx}, reward on first task: {result.mean_reward:.2f}")
+
+
+def main():
+    base_model = run_base_training(timesteps=100)
+    print("\n--- Residual RL comparison ---")
+    residual_model = rrl_comparison(base_model, timesteps=100)
+
+    print("\n--- Progressive learning over tasks ---")
+    task_params = [
+        {"T_c": 0.35},
+        {"T_c": 0.40},
+        {"T_c": 0.45},
+    ]
+    progressive_learning(base_model, task_params, timesteps=100)
+
+    print("\n--- Ablation: remove PNN (fine-tune single residual) ---")
+    ablation_remove_pnn(base_model, task_params, timesteps=100)
+
+
+if __name__ == "__main__":
+    main()

--- a/pse_environments/__init__.py
+++ b/pse_environments/__init__.py
@@ -1,2 +1,6 @@
-if not __name__ == "__main__":
-    from . import environments
+"""Environment package exports."""
+
+if __name__ != "__main__":
+    from . import environments  # noqa: F401
+    from .cstr import CSTR1Env  # noqa: F401
+

--- a/pse_environments/cstr.py
+++ b/pse_environments/cstr.py
@@ -50,7 +50,8 @@ class CSTR1():
                  normalize_state = True,
                  normalize_action = True,
                  discrete_model = None,
-                 device=None
+                 device=None,
+                 param_overrides=None
                  ):
         self.delta_t = delta_t
         self.normalize_state = normalize_state
@@ -106,6 +107,8 @@ class CSTR1():
                      'roh': 1.0/(60.0*60.0),
                      'T': 0.7293,
                      'Fc': 390.0/(60.0*60.0)}}
+        if param_overrides:
+            self.cstr_parameters.update(param_overrides)
         
         # stuff needed for model-based RL algorithms
         self.discrete_model = discrete_model
@@ -209,6 +212,77 @@ class CSTR1():
         else:
             raise ValueError('storage_initialization must be "empty", "random" or a float')
         return storage
+
+
+class CSTR1Env(gym.Env):
+    """Gymnasium environment wrapper for :class:`CSTR1`.
+
+    The environment exposes the two normalized states (concentration ``c`` and
+    temperature ``T``) as observations and expects two normalized control
+    inputs.  Rewards are set to zero by default – the class only models the
+    system dynamics.  Episodes terminate after ``episode_length`` steps.
+    """
+
+    metadata = {"render_modes": []}
+
+    def __init__(self, delta_t, normalize_state=True, normalize_action=True,
+                 episode_length=200, device=None, param_overrides=None,
+                 c_target: float = 0.6):
+        super().__init__()
+        self.model = CSTR1(delta_t, normalize_state=normalize_state,
+                           normalize_action=normalize_action, device=device,
+                           param_overrides=param_overrides)
+        self.action_space = self.model.action_space
+        if normalize_state:
+            low = -np.ones(self.model.n_states, dtype=np.float32)
+            high = np.ones(self.model.n_states, dtype=np.float32)
+        else:
+            low = self.model.x_bounds['lower'].cpu().numpy()
+            high = self.model.x_bounds['upper'].cpu().numpy()
+        self.observation_space = gym.spaces.Box(low=low, high=high,
+                                                dtype=np.float32)
+        self.episode_length = episode_length
+        self.device = self.model.device
+        self.state = None
+        self.steps = 0
+        self.c_target = c_target
+
+    def step(self, action):
+        if isinstance(action, np.ndarray):
+            action = torch_.tensor(action, dtype=torch_.float32,
+                                   device=self.device)
+        x, _, _, _ = self.model.forward(self.state, action)
+        self.state = x[-1]
+        self.steps += 1
+        obs = (self.state.cpu().numpy() if isinstance(self.state, torch_.Tensor)
+               else self.state)
+        # compute reward based on concentration error
+        if self.model.normalize_state:
+            c_current = (
+                self.model.state_scaler.unscale(self.state)[0].item()
+                if isinstance(self.state, torch_.Tensor)
+                else self.model.state_scaler.unscale(torch_.tensor(self.state))[0].item()
+            )
+        else:
+            c_current = (
+                self.state[0].item() if isinstance(self.state, torch_.Tensor)
+                else self.state[0]
+            )
+        error = c_current - self.c_target
+        reward = -(error ** 2)
+        terminated = False
+        truncated = self.steps >= self.episode_length
+        info = {"c": c_current}
+        return obs, reward, terminated, truncated, info
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        self.state = self.model.get_initial_state()
+        self.steps = 0
+        obs = (self.state.cpu().numpy() if isinstance(self.state, torch_.Tensor)
+               else self.state)
+        info = {}
+        return obs, info
 
 ### Testing
 if __name__ == '__main__':

--- a/residual_cstr_agent.py
+++ b/residual_cstr_agent.py
@@ -1,0 +1,135 @@
+"""Residual RL example for the CSTR environment.
+
+This script trains a base SAC policy that regulates the reactor
+concentration toward ``c = 0.6`` and then adapts to a perturbed
+environment (different coolant temperature) using a residual policy.  The
+resulting trajectories for the base-only and base+residual controllers are
+plotted for comparison.
+"""
+
+from typing import Optional, Dict, List
+
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+import gymnasium as gym
+from stable_baselines3 import SAC
+
+from pse_environments import CSTR1Env
+
+
+def make_env(param_overrides: Optional[Dict[str, float]] = None) -> CSTR1Env:
+    """Construct a ``CSTR1Env`` with optional parameter overrides."""
+
+    delta_t = {"timestep": 15 * 60.0, "control": 60 * 60.0}
+    env = CSTR1Env(delta_t, episode_length=50, param_overrides=param_overrides)
+    return env
+
+
+def train_base(total_timesteps: int = 100) -> SAC:
+    """Train a base SAC policy on the nominal environment."""
+
+    env = make_env()
+    model = SAC("MlpPolicy", env, verbose=0)
+    model.learn(total_timesteps=total_timesteps)
+    return model
+
+
+class ResidualWrapper(gym.Env):
+    """Environment wrapper that applies a base policy before residual actions.
+
+    Parameters
+    ----------
+    env : gym.Env
+        Wrapped environment.
+    base_policy : SAC
+        Frozen policy providing baseline actions.
+    residual_policies : list[SAC], optional
+        Previously learned residual policies whose actions are composed before
+        the new residual action.  This allows progressive stacking of residual
+        controllers when learning a sequence of tasks.
+    """
+
+    def __init__(
+        self,
+        env: gym.Env,
+        base_policy: SAC,
+        residual_policies: Optional[List[SAC]] = None,
+    ):
+        super().__init__()
+        self.env = env
+        self.base_policy = base_policy
+        self.residual_policies = residual_policies or []
+        self.action_space = env.action_space
+        self.observation_space = env.observation_space
+        self._last_obs = None
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        obs, info = self.env.reset(seed=seed, options=options)
+        self._last_obs = obs
+        return obs, info
+
+    def step(self, residual_action):
+        base_action, _ = self.base_policy.predict(self._last_obs, deterministic=True)
+
+        for pol in self.residual_policies:
+            corr, _ = pol.predict(self._last_obs, deterministic=True)
+            base_action = np.clip(
+                base_action + corr,
+                self.env.action_space.low,
+                self.env.action_space.high,
+            )
+
+        final_action = np.clip(
+            base_action + residual_action,
+            self.env.action_space.low,
+            self.env.action_space.high,
+        )
+        obs, reward, terminated, truncated, info = self.env.step(final_action)
+        self._last_obs = obs
+        return obs, reward, terminated, truncated, info
+
+
+def train_residual(base_model: SAC, total_timesteps: int = 100) -> SAC:
+    """Train a residual SAC policy on a modified environment."""
+
+    # Modify the coolant temperature parameter to create a new environment
+    env = make_env(param_overrides={"T_c": 0.40})
+    residual_env = ResidualWrapper(env, base_model)
+    model = SAC("MlpPolicy", residual_env, verbose=0)
+    model.learn(total_timesteps=total_timesteps)
+    return model
+
+
+if __name__ == "__main__":
+    base = train_base(total_timesteps=200)
+    residual = train_residual(base, total_timesteps=200)
+
+    # Evaluate in a perturbed environment
+    eval_env_base = make_env(param_overrides={"T_c": 0.40})
+    eval_env_res = ResidualWrapper(make_env(param_overrides={"T_c": 0.40}), base)
+
+    def rollout(env, policy, steps=50):
+        obs, _ = env.reset()
+        traj = []
+        for _ in range(steps):
+            action, _ = policy.predict(obs, deterministic=True)
+            obs, reward, terminated, truncated, _ = env.step(action)
+            c_val = env.model.state_scaler.unscale(torch.tensor(obs))[0].item() if isinstance(env, CSTR1Env) else env.env.model.state_scaler.unscale(torch.tensor(obs))[0].item()
+            traj.append(c_val)
+            if terminated or truncated:
+                break
+        return traj
+
+    base_traj = rollout(eval_env_base, base)
+    res_traj = rollout(eval_env_res, residual)
+
+    plt.plot(base_traj, label="Base only")
+    plt.plot(res_traj, label="Base + residual")
+    plt.axhline(eval_env_base.c_target, color="r", linestyle="--", label="target")
+    plt.xlabel("Step")
+    plt.ylabel("Concentration c")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig("residual_cstr_trajectory.png")
+    print("Trajectory plot saved to residual_cstr_trajectory.png")

--- a/sac_cstr_agent.py
+++ b/sac_cstr_agent.py
@@ -1,0 +1,70 @@
+"""Basic SAC training script for CSTR1Env.
+
+This script demonstrates how to create the environment and train a
+Soft Actor-Critic agent from Stable-Baselines3 for a small number of
+steps.  It can be used as a starting point for more advanced
+experiments.
+"""
+
+from stable_baselines3 import SAC
+import gymnasium as gym
+import torch
+import matplotlib.pyplot as plt
+from pse_environments import CSTR1Env
+
+
+def make_env():
+    """Construct a single instance of :class:`CSTR1Env`.
+
+    Returns
+    -------
+    env : CSTR1Env
+        Environment with default sampling intervals and a short
+        episode length for quick experiments.
+    """
+    delta_t = {"timestep": 15 * 60.0, "control": 60 * 60.0}
+    env = CSTR1Env(delta_t, episode_length=50)
+    return env
+
+
+def train_example(total_timesteps: int = 100) -> SAC:
+    """Train a minimal SAC agent on the CSTR1Env.
+
+    Parameters
+    ----------
+    total_timesteps: int
+        Number of training timesteps.  Keep this low for quick
+        demonstrations; increase for better policies.
+
+    Returns
+    -------
+    model : SAC
+        Trained SAC model.
+    """
+    env = make_env()
+    model = SAC("MlpPolicy", env, verbose=0)
+    model.learn(total_timesteps=total_timesteps)
+    return model
+
+
+if __name__ == "__main__":
+    model = train_example(total_timesteps=200)
+    env = make_env()
+    obs, _ = env.reset()
+    concentrations = []
+    for _ in range(50):
+        action, _ = model.predict(obs, deterministic=True)
+        obs, reward, terminated, truncated, info = env.step(action)
+        c_val = env.model.state_scaler.unscale(torch.tensor(obs))[0].item()
+        concentrations.append(c_val)
+        if terminated or truncated:
+            break
+
+    plt.plot(concentrations, label="SAC policy")
+    plt.axhline(env.c_target, color="r", linestyle="--", label="target")
+    plt.xlabel("Step")
+    plt.ylabel("Concentration c")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig("sac_cstr_trajectory.png")
+    print("Trajectory plot saved to sac_cstr_trajectory.png")


### PR DESCRIPTION
## Summary
- track concentration deviation in CSTR1Env with quadratic penalty
- add plotting evaluations for SAC and residual controllers

## Testing
- `python sac_cstr_agent.py`
- `python residual_cstr_agent.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb8a2fae08325985b62b3428ba22f